### PR TITLE
Pin alpine version to 3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ADD http://www.random.org/strings/?num=10&len=8&digits=on&upperalpha=on&loweralp
 ENV BCOIN_BRANCH=master \
     BCOIN_REPO=https://github.com/bcoin-org/bcoin.git
 
-RUN apk --no-cache add bash build-base git make nodejs=6.9.2-r1 python unrar \
+RUN apk --no-cache add bash build-base git make nodejs python unrar \
     && mkdir -p /code/node_modules/bcoin /data \
     && git clone --branch $BCOIN_BRANCH $BCOIN_REPO /code/node_modules/bcoin \
     && cd /code/node_modules/bcoin \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,17 @@
-FROM alpine:edge
+FROM alpine:3.5
 MAINTAINER Steven Bower <steven@purse.io>
 
-# Cache buster
 ADD http://www.random.org/strings/?num=10&len=8&digits=on&upperalpha=on&loweralpha=on&unique=on&format=plain&rnd=new uuid
 
-# Build deps
-RUN apk update && \
-    apk upgrade
-RUN apk add nodejs bash unrar git python build-base make
+ENV BCOIN_BRANCH=master \
+    BCOIN_REPO=https://github.com/bcoin-org/bcoin.git
 
-ENV BCOIN_BRANCH master
-ENV BCOIN_REPO https://github.com/bcoin-org/bcoin.git
-
-RUN mkdir -p /code/node_modules/bcoin /data
-
-RUN git clone --branch $BCOIN_BRANCH $BCOIN_REPO /code/node_modules/bcoin
-
-# Installation
-WORKDIR /code/node_modules/bcoin
-RUN npm install --production
-
-# Cleanup
-RUN npm uninstall node-gyp
-RUN apk del unrar python build-base make && \
-    rm /var/cache/apk/*
+RUN apk --no-cache add bash build-base git make nodejs=6.9.2-r1 python unrar \
+    && mkdir -p /code/node_modules/bcoin /data \
+    && git clone --branch $BCOIN_BRANCH $BCOIN_REPO /code/node_modules/bcoin \
+    && cd /code/node_modules/bcoin \
+    && npm install --production \
+    && npm uninstall node-gyp \
+    && apk del build-base make python unrar
 
 CMD ["node", "/code/node_modules/bcoin/bin/node"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.5
 MAINTAINER Steven Bower <steven@purse.io>
 
+# Cache buster
 ADD http://www.random.org/strings/?num=10&len=8&digits=on&upperalpha=on&loweralpha=on&unique=on&format=plain&rnd=new uuid
 
 ENV BCOIN_BRANCH=master \

--- a/README.md
+++ b/README.md
@@ -11,15 +11,32 @@ Container based on AlpineLinux for speed and portability.
 How To Use
 ----
 
-Copy sample configuration to `secrets/bcoin.conf`.
+Copy sample configuration to `secrets/bcoin.conf`:
+>Important: Be sure to keep API secrets safe.
+```
+$ mkdir -p secrets
+$ cp bcoin.example.conf secrets/bcoin.conf
+```
 
-Important: Be sure to keep API secrets safe.
+Create `bcoin` network:
+```
+$ docker network create bcoin
+```
+
+Create `nginx-proxy` network:
+```
+$ docker network create nginx-proxy
+```
 
 Quick run, node only:
-`docker-compose up -d bcoin`
+```
+$ docker-compose up -d bcoin
+```
 
-Update to latest bcoin & alpine version:
-`docker-compose build --pull bcoin`
+Update to latest bcoin version:
+```
+$ docker-compose build --pull bcoin
+```
 
 HTTPS
 ----

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,6 @@ services:
 networks:
   bcoin:
     external:
-      # docker network create bcoin
       name: "bcoin"
   nginx-proxy:
     external:


### PR DESCRIPTION
The default node version has been updated to 6.10.1-r0 for alpine edge.
This version lists npm as a sub-package and does not install it during
its own install process. This is causing the Dockerfile build to fail on `master`.
Alpine has been pinned to v3.5 (which installs nodejs to 6.9.2-r2). This is the
latest version of node (on alpine) that installs npm as well.

This commit also optimizes the image build. Currently the built image
size is 305MB. By minimizing the amount of layers created during the
build process, the image size has been reduced by a factor of almost
three (117MB). 