### PR TITLE
Fixed volume mapping issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - "bcoin"
       - "nginx-proxy"
     volumes:
-      - ~/.bcoin:/data
+      - ~/.bcoin:/root/.bcoin
       - ${PWD}/secrets/bcoin.conf:/data/bcoin.conf
 
   nginx_proxy:


### PR DESCRIPTION
The bcoin container was never being able to run since there was an errore mapping `.bcoin` to data.