### PR TITLE
Change python2 to python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN git clone $BCOIN_REPO /code && \
 FROM base AS build
 
 # Install build dependencies
-RUN apk add --no-cache g++ gcc make python2
+RUN apk add --no-cache g++ gcc make python3
 RUN npm install --production
 
 # Copy built files, but don't include build deps


### PR DESCRIPTION
Python2 is now deprecated for dependency packages. When trying to build with python2 you will get this message:

```
STEP 10: RUN npm install --production
npm ERR! code 1
npm ERR! git dep preparation failed
npm ERR! command /usr/local/bin/node /usr/local/lib/node_modules/npm/bin/npm-cli.js install --force --cache=/root/.npm --prefer-offline=false --prefer-online=false --offline=false --no-progress --no-save --no-audit --include=dev --include=peer --include=optional --no-package-lock-only --no-dry-run
npm ERR! > bdb@1.2.2 install
npm ERR! > node-gyp rebuild
npm ERR! npm WARN using --force Recommended protections disabled.
npm ERR! npm WARN old lockfile 
npm ERR! npm WARN old lockfile The package-lock.json file was created with an old version of npm,
npm ERR! npm WARN old lockfile so supplemental metadata must be fetched from the registry.
npm ERR! npm WARN old lockfile 
npm ERR! npm WARN old lockfile This is a one-time fix-up, please be patient...
npm ERR! npm WARN old lockfile 
npm ERR! gyp info it worked if it ends with ok
npm ERR! gyp info using node-gyp@9.0.0
npm ERR! gyp info using node@17.8.0 | linux | x64
npm ERR! gyp ERR! find Python 
npm ERR! gyp ERR! find Python Python is not set from command line or npm configuration
npm ERR! gyp ERR! find Python Python is not set from environment variable PYTHON
npm ERR! gyp ERR! find Python checking if "python3" can be used
npm ERR! gyp ERR! find Python - "python3" is not in PATH or produced an error
npm ERR! gyp ERR! find Python checking if "python" can be used
npm ERR! gyp ERR! find Python - executable path is "/usr/bin/python"
npm ERR! gyp ERR! find Python - version is "2.7.18"
npm ERR! gyp ERR! find Python - version is 2.7.18 - should be >=3.6.0
npm ERR! gyp ERR! find Python - THIS VERSION OF PYTHON IS NOT SUPPORTED
npm ERR! gyp ERR! find Python 
npm ERR! gyp ERR! find Python **********************************************************
npm ERR! gyp ERR! find Python You need to install the latest version of Python.
npm ERR! gyp ERR! find Python Node-gyp should be able to find and use Python. If not,
npm ERR! gyp ERR! find Python you can try one of the following options:
npm ERR! gyp ERR! find Python - Use the switch --python="/path/to/pythonexecutable"
npm ERR! gyp ERR! find Python   (accepted by both node-gyp and npm)
npm ERR! gyp ERR! find Python - Set the environment variable PYTHON
npm ERR! gyp ERR! find Python - Set the npm configuration variable python:
npm ERR! gyp ERR! find Python   npm config set python "/path/to/pythonexecutable"
npm ERR! gyp ERR! find Python For more information consult the documentation at:
npm ERR! gyp ERR! find Python https://github.com/nodejs/node-gyp#installation
npm ERR! gyp ERR! find Python **********************************************************
npm ERR! gyp ERR! find Python 
npm ERR! gyp ERR! configure error 
npm ERR! gyp ERR! stack Error: Could not find any Python installation to use
npm ERR! gyp ERR! stack     at PythonFinder.fail (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:330:47)
npm ERR! gyp ERR! stack     at PythonFinder.runChecks (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:159:21)
npm ERR! gyp ERR! stack     at PythonFinder.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:266:16)
npm ERR! gyp ERR! stack     at PythonFinder.execFileCallback (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:297:7)
npm ERR! gyp ERR! stack     at ChildProcess.exithandler (node:child_process:390:7)
npm ERR! gyp ERR! stack     at ChildProcess.emit (node:events:527:28)
npm ERR! gyp ERR! stack     at maybeClose (node:internal/child_process:1090:16)
npm ERR! gyp ERR! stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:302:5)
npm ERR! gyp ERR! System Linux 5.13.0-37-generic
npm ERR! gyp ERR! command "/usr/local/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
npm ERR! gyp ERR! cwd /root/.npm/_cacache/tmp/git-cloneGCIKmE
npm ERR! gyp ERR! node -v v17.8.0
npm ERR! gyp ERR! node-gyp -v v9.0.0
npm ERR! gyp ERR! not ok 
npm ERR! npm ERR! code 1
npm ERR! npm ERR! path /root/.npm/_cacache/tmp/git-cloneGCIKmE
npm ERR! npm ERR! command failed
npm ERR! npm ERR! command sh -c node-gyp rebuild
npm ERR! 
npm ERR! npm ERR! A complete log of this run can be found in:
npm ERR! npm ERR!     /root/.npm/_logs/2022-03-26T16_57_22_951Z-debug-0.log

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2022-03-26T16_56_33_606Z-debug-0.log
error building at STEP "RUN npm install --production": error while running runtime: exit status 1
ERRO[0105] exit status 1  
```

This commit fixes this issue by changing the dockerfile to python3 and is confirmed to build for arm64 and amd64 images which can be viewed and verified via `docker pull gildedpleb/bcoin:v2.2.0`