### PR TITLE
fix(docker-compose): Move from deprecated network config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,6 @@ services:
 
 networks:
   bcoin:
-    external:
-      name: "bcoin"
+    external: true
   nginx-proxy:
-    external:
-      name: "nginx-proxy"
+    external: true


### PR DESCRIPTION
```
root@cryptonode:/opt/bcoin# docker compose up  -d
WARN[0000] network nginx-proxy: network.external.name is deprecated. Please set network.name with external: true
WARN[0000] network bcoin: network.external.name is deprecated. Please set network.name with external: true
```
https://github.com/docker/compose-cli/issues/1856#issuecomment-1108552064